### PR TITLE
adapt to cdk-nag 2.14.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea/
+/**/package-lock.json

--- a/multi-step-functions-eventbridge/lib/multi-step-functions-eventbridge-stack.ts
+++ b/multi-step-functions-eventbridge/lib/multi-step-functions-eventbridge-stack.ts
@@ -52,6 +52,22 @@ export class MultiStepFunctionsEventbridgeStack extends cdk.Stack {
       encryptionMasterKey: kmsKey
     });
 
+  
+    const enforceTlsStatement = new iam.PolicyStatement({
+      sid: "Enforce TLS for all principals",
+      effect: iam.Effect.DENY,
+      principals: [
+          new iam.AnyPrincipal(),
+      ],
+      actions: [
+          "sqs:*",
+      ],
+      conditions: {
+          "Bool": {"aws:SecureTransport": false},
+      },
+    }  );
+    computingBusDLQ.addToResourcePolicy(enforceTlsStatement);
+
     // Enable adding suppressions to computingBusDLQ to notify CDK-NAG that 
     // This computingBusDLQ sqs queue is already a deadletter queue for eventbridge
     // bus computingBus so itself does not need another deadletter queue
@@ -85,7 +101,7 @@ export class MultiStepFunctionsEventbridgeStack extends cdk.Stack {
     computingLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const computingLambda = new lambda.Function(this, 'computing_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: computingLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'computing_lambda.lambda_handler',
@@ -137,7 +153,7 @@ export class MultiStepFunctionsEventbridgeStack extends cdk.Stack {
     summaryLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const summaryLambda = new lambda.Function(this, 'summary_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: summaryLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'summary_lambda.lambda_handler',

--- a/step-function-map-in-map/lib/step-function-map-in-map-stack.ts
+++ b/step-function-map-in-map/lib/step-function-map-in-map-stack.ts
@@ -32,7 +32,7 @@ export class StepFunctionMapInMapStack extends cdk.Stack {
     computingLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const computingLambda = new lambda.Function(this, 'computing_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'computing_lambda.lambda_handler',
       architecture: lambda.Architecture.ARM_64,
@@ -73,7 +73,7 @@ export class StepFunctionMapInMapStack extends cdk.Stack {
     summaryLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const summaryLambda = new lambda.Function(this, 'summary_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: summaryLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'summary_lambda.lambda_handler',

--- a/step-function-map-in-parallel/lib/step-function-map-in-parallel-stack.ts
+++ b/step-function-map-in-parallel/lib/step-function-map-in-parallel-stack.ts
@@ -31,7 +31,7 @@ export class StepFunctionMapInParallelStack extends cdk.Stack {
     computingLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const computingLambda = new lambda.Function(this, 'computing_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: computingLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'computing_lambda.lambda_handler',
@@ -74,7 +74,7 @@ export class StepFunctionMapInParallelStack extends cdk.Stack {
     summaryLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const summaryLambda = new lambda.Function(this, 'summary_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: summaryLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'summary_lambda.lambda_handler',

--- a/step-function-map-iterator/lib/step-function-map-iterator-stack.ts
+++ b/step-function-map-iterator/lib/step-function-map-iterator-stack.ts
@@ -32,7 +32,7 @@ export class StepFunctionMapIteratorStack extends cdk.Stack {
 
 
     const computingLambda = new lambda.Function(this, 'computing_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: computingLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'computing_lambda.lambda_handler',
@@ -75,7 +75,7 @@ export class StepFunctionMapIteratorStack extends cdk.Stack {
     summaryLambdaRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSXRayDaemonWriteAccess'));
 
     const summaryLambda = new lambda.Function(this, 'summary_lambda', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_16_X,
       role: summaryLambdaRole,
       code: lambda.Code.fromAsset('lambda_fns'),
       handler: 'summary_lambda.lambda_handler',


### PR DESCRIPTION
- enforce aws:SecureTransport on SQS queues
- update lambda runtime to latest version
have .gitignore file to ignore package-lock.json files


*Description of changes:*
added a ResourcePolicy to enforce `aws:SecureTranport` on the SQS queues ( this complies to AwsSolutions-SQS4 )
updated the runtime version of the lambda functions to NODEJS_16_X ( complies to AwsSolutions-L1 )
I also added a .gitignore file that ignores the package-lock.json files to prevent them from accidentally being commited.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
